### PR TITLE
Add hoc to render custom component

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ render(<App />, document.getElementById("root"));
 | suffix | string  | '' | String used as suffix for the masked value |
 | precision | number | 2 | Number of fraction digits to use |
 | onChange | function | n/a | `(event, value, maskedValue) => {}`<br>Callback function to handle value changes |
+| children | function | n/a | `(props) => React.Element`<br>HOC to render a custom input |
 
 ## Examples
 
@@ -94,3 +95,13 @@ render(<App />, document.getElementById("root"));
       precision={2}
     />
 ```
+
+```javascript
+    <IntlNumberInput
+      onChange={handleChange}
+      value={value}
+    >
+      {props => <CustomInput {...props} />}
+    </IntlNumberInput>
+```
+`onChange` and `value` must be passed to `IntlNumberInput` and not the child component in order for the formatting to work

--- a/example/index.js
+++ b/example/index.js
@@ -55,6 +55,11 @@ class App extends React.Component {
           />
         </p>
         <p>
+          <IntlNumberInput value={this.state.value} onChange={this.handleChange}   >
+            {props => <CustomInput {...props} />}
+          </IntlNumberInput>
+        </p>
+        <p>
           value: {this.state.value}
         </p>
         <p>
@@ -63,6 +68,12 @@ class App extends React.Component {
       </div>
     );
   }
+}
+
+function CustomInput (props) {
+  return (
+    <input style={{ background: 'deepskyblue' }} {...props} />
+  )
 }
 
 render(<App />, document.getElementById("root"));

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -91,11 +91,22 @@ class IntlNumberInput extends Component {
     delete customProps.autoFocus;
     delete customProps.value;
     delete customProps.onChange;
+    delete customProps.children;
 
     return customProps;
   }
 
   render() {
+
+    if (this.props.children && typeof(this.props.children) === 'function'){
+      return this.props.children({
+        value: this.state.maskedValue,
+        disabled: this.props.disabled,
+        onChange: e => this.handleChange(e),
+        ...this.customProps(),
+      });
+    }
+
     return (
       <input
         value={this.state.maskedValue}
@@ -115,6 +126,7 @@ IntlNumberInput.propTypes = {
   value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   disabled: PropTypes.bool,
   onChange: PropTypes.func,
+  children: PropTypes.func,
 };
 
 IntlNumberInput.defaultProps = {


### PR DESCRIPTION
The change add optional children to the `IntlNumberInput` component that will behave as a HOC. That way, any custom input can be used (from any UI Library for instance).
Preferably the component must have an input, but props will have `value` that can be used to show the 
formatted value.
In addition to the main file, the example and readme were updated.